### PR TITLE
Fix adding local genomes in the Docker container

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,6 +29,7 @@ RUN mkdir -p /data/www \
     && echo 'JOBQUEUEDB = "/data/temp/crisporJobs.db"' > /data/www/crispor/crispor.conf \
     && mkdir -p /data/genomes/ \
     && ln -s /data/genomes /data/www/crispor/genomes \
+    && ln -s /data/genomes /data/www/genomes \
     && mkdir -p /data/temp/ \
     && chmod a+rw /data/temp \
     && ln -s /data/temp /data/www/crispor/temp \

--- a/docker/README.md
+++ b/docker/README.md
@@ -8,8 +8,7 @@ initd.
 
 To download and start the container and map the port 8080 on your machine to the container:
 
-     docker run -d -p 8080:80 --name crispor-container maximilianh/crispor /sbin/my_ini
-
+     docker run -d -p 8080:80 --name crispor-container maximilianh/crispor
 You should then be able to access the container via http://localhost from the machine. There is no genome yet.
 
 To download an existing genome from crispor.gi.ucsc.edu into the container:
@@ -25,7 +24,7 @@ The syntax for the --desc option is: "internalName|latinName|commonName|assembly
 
 To get a linux shell in the running docker container:
 
-     docker exec -it crispor-container333 /bin/bash
+     docker exec -it crispor-container /bin/bash
 
 From outside the container, from a clone of the Github repo, I run this command to build the container and push it as a multi-architecture build, you do not have to do this, but it may be interesting:
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -9,7 +9,7 @@ initd.
 To download and start the container and map the port 8080 on your machine to the container:
 
      docker run -d -p 8080:80 --name crispor-container maximilianh/crispor
-You should then be able to access the container via http://localhost from the machine. There is no genome yet.
+You should then be able to access the container via http://localhost:8080 from the machine. There is no genome yet.
 
 To download an existing genome from crispor.gi.ucsc.edu into the container:
 
@@ -19,6 +19,15 @@ To add a new genome to the container, either via NCBI accession or from a FASTA/
 
      docker exec -it crispor-container /data/www/crispor/tools/crisporAddGenome ncbi GCA_052724335.1
      docker exec -it crispor-container /data/www/crispor/tools/crisporAddGenome fasta GWHBOWM00000000.genome.fasta.gz --gff GWHBOWM00000000.gff.gz --desc 'faAtrBel|Atropa belladonna|Belladonna deadly nightshade|CNCB GWHBOWM00000000'
+
+You can make fasta files from the host available for adding by including a bind mount when you execute docker run.
+For example, you can run
+
+     docker exec -d -p 8080:80 -v /path/to/genome.fa:/tmp/genome.fa --name crispor-container maximilianh/crispor
+
+When you run `crisporAddGenome` via `docker exec`, the genome will be available at `/tmp/genome.fa`. If you wish to include
+multiple genomes at the same time, you can use a directory with multiple fasta files instead:
+`/path/to/genomes_dir:/tmp/genomes_dir`. Then every file in `genomes_dir` will be available at `/tmp/genomes_dir/genome_name.fa`
 
 The syntax for the --desc option is: "internalName|latinName|commonName|assembly version or description'
 


### PR DESCRIPTION
The current docker container can't add new genomes (at least from local files). This is because `crisporAddGenome` outputs to `/data/www/genomes`, but `makeGenomeInfo` looks in `/data/www/crispor/genomes`, which is symlinked to `/data/genomes`.

This pull request adds a symlink from `/data/genomes` to `/data/www/genomes`, which should fix the issue. Alternately, `crisporAddGenome` could output to `/data/genomes` or `/data/www/crispor/genomes`, but I don't know if that would break other installation methods.

I've also slightly updated the documentation to clarify how to run the container, as well as make files available in it for adding to the website.